### PR TITLE
fix(passwd): fix memory leak in ruri_get_groups()

### DIFF
--- a/src/passwd.c
+++ b/src/passwd.c
@@ -739,5 +739,6 @@ int ruri_get_groups(uid_t uid, gid_t groups[])
 		}
 	}
 	free(username);
+	free(buf);
 	return ret;
 }


### PR DESCRIPTION
The 'buf' variable allocated with malloc() was not being freed before returning from ruri_get_groups(), causing a memory leak detected by LeakSanitizer when running in systemd mode.

Fix by adding free(buf) before the return statement.