### PR TITLE
refactor: extract common functions and fix security issues

### DIFF
--- a/src/chroot.c
+++ b/src/chroot.c
@@ -131,7 +131,7 @@ static void generate_machine_id(int container_id)
 	new_machine_id[32] = '\0';
 	remove("/etc/machine-id");
 	unlink("/etc/machine-id");
-	int machine_id_fd = open("/etc/machine-id", O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	int machine_id_fd = open("/etc/machine-id", O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (machine_id_fd >= 0) {
 		write(machine_id_fd, new_machine_id, 32);
 		write(machine_id_fd, "\n", 1);
@@ -256,8 +256,7 @@ static void init_container(struct RURI_CONTAINER *_Nonnull container)
 		if (container->memory == NULL) {
 			devshm_options = strdup("mode=1777");
 		} else {
-			devshm_options = malloc(strlen(container->memory) + strlen("mode=1777") + 114);
-			sprintf(devshm_options, "size=65536k,mode=1777");
+			devshm_options = strdup("size=65536k,mode=1777");
 		}
 		res = mkdir("/dev/shm", S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH | S_IRGRP | S_IWGRP);
 		ruri_warn_on_error(res, 0, !container->no_warnings, "{yellow}Warning: Failed to create /dev/shm, will continue.\n");
@@ -314,37 +313,7 @@ static void init_container(struct RURI_CONTAINER *_Nonnull container)
 		}
 		if (!container->unmask_dirs) {
 			// Mask some directories/files that we don't want the container modify it.
-			mount("tmpfs", "/proc/asound", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/proc/acpi", "tmpfs", MS_RDONLY, NULL);
-			mount("/dev/null", "/proc/kcore", "", MS_BIND, NULL);
-			mount("/dev/null", "/proc/keys", "", MS_BIND, NULL);
-			mount("/dev/null", "/proc/latency_stats", "", MS_BIND, NULL);
-			mount("/dev/null", "/proc/timer_list", "", MS_BIND, NULL);
-			mount("/dev/null", "/proc/timer_stats", "", MS_BIND, NULL);
-			mount("/dev/null", "/proc/sched_debug", "", MS_BIND, NULL);
-			mount("/dev/null", "/proc/sysrq-trigger", "", MS_BIND, NULL);
-			mount("tmpfs", "/proc/scsi", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/sys/firmware", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/sys/devices/virtual/powercap", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/sys/block", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/sys/kernel/debug", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/sys/module", "tmpfs", MS_RDONLY, NULL);
-			mount("tmpfs", "/sys/class/net", "tmpfs", MS_RDONLY, NULL);
-			if (!container->systemd_mode) {
-				mount("tmpfs", "/sys/fs/cgroup", "tmpfs", MS_RDONLY, NULL);
-			}
-			// Protect some system runtime directories by mounting themselves as read-only.
-			mount("/proc/bus", "/proc/bus", NULL, MS_BIND | MS_REC, NULL);
-			mount("/proc/bus", "/proc/bus", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
-			mount("/proc/fs", "/proc/fs", NULL, MS_BIND | MS_REC, NULL);
-			mount("/proc/fs", "/proc/fs", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
-			mount("/proc/irq", "/proc/irq", NULL, MS_BIND | MS_REC, NULL);
-			mount("/proc/irq", "/proc/irq", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
-			mount("/proc/sys", "/proc/sys", NULL, MS_BIND | MS_REC, NULL);
-			mount("/proc/sys", "/proc/sys", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
-			mount("/proc/sys-trigger", "/proc/sys-trigger", NULL, MS_BIND | MS_REC, NULL);
-			mount("/proc/sys-trigger", "/proc/sys-trigger", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
-			mount("/dev/null", "/sys/class/tty/console/active", NULL, MS_BIND, NULL);
+			ruri_mask_proc_sys(container);
 		}
 		// Mask other user-specified path.
 		for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i++) {
@@ -833,6 +802,102 @@ static void hidepid(int stat)
 		mount("none", "/proc", "proc", MS_REMOUNT, "hidepid=2");
 	}
 }
+void ruri_block_tty_signals(void)
+{
+	/*
+	 * Block SIGTTIN and SIGTTOU signals.
+	 * This is useful when running in the background.
+	 */
+	sigset_t sigs;
+	sigemptyset(&sigs);
+	sigaddset(&sigs, SIGTTIN);
+	sigaddset(&sigs, SIGTTOU);
+	sigprocmask(SIG_BLOCK, &sigs, 0);
+}
+void ruri_mask_proc_sys(const struct RURI_CONTAINER *_Nonnull container)
+{
+	/*
+	 * Mask some directories/files in /sys and /proc
+	 * to avoid security issues.
+	 */
+	if (container->unmask_dirs) {
+		return;
+	}
+	mount("tmpfs", "/proc/asound", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/proc/acpi", "tmpfs", MS_RDONLY, NULL);
+	mount("/dev/null", "/proc/kcore", "", MS_BIND, NULL);
+	mount("/dev/null", "/proc/keys", "", MS_BIND, NULL);
+	mount("/dev/null", "/proc/latency_stats", "", MS_BIND, NULL);
+	mount("/dev/null", "/proc/timer_list", "", MS_BIND, NULL);
+	mount("/dev/null", "/proc/timer_stats", "", MS_BIND, NULL);
+	mount("/dev/null", "/proc/sched_debug", "", MS_BIND, NULL);
+	mount("/dev/null", "/proc/sysrq-trigger", "", MS_BIND, NULL);
+	mount("tmpfs", "/proc/scsi", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/sys/firmware", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/sys/devices/virtual/powercap", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/sys/block", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/sys/kernel/debug", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/sys/module", "tmpfs", MS_RDONLY, NULL);
+	mount("tmpfs", "/sys/class/net", "tmpfs", MS_RDONLY, NULL);
+	if (!container->systemd_mode) {
+		mount("tmpfs", "/sys/fs/cgroup", "tmpfs", MS_RDONLY, NULL);
+	}
+	mount("/proc/bus", "/proc/bus", NULL, MS_BIND | MS_REC, NULL);
+	mount("/proc/bus", "/proc/bus", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
+	mount("/proc/fs", "/proc/fs", NULL, MS_BIND | MS_REC, NULL);
+	mount("/proc/fs", "/proc/fs", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
+	mount("/proc/irq", "/proc/irq", NULL, MS_BIND | MS_REC, NULL);
+	mount("/proc/irq", "/proc/irq", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
+	mount("/proc/sys", "/proc/sys", NULL, MS_BIND | MS_REC, NULL);
+	mount("/proc/sys", "/proc/sys", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
+	mount("/proc/sys-trigger", "/proc/sys-trigger", NULL, MS_BIND | MS_REC, NULL);
+	mount("/proc/sys-trigger", "/proc/sys-trigger", NULL, MS_BIND | MS_RDONLY | MS_REMOUNT, NULL);
+	mount("/dev/null", "/sys/class/tty/console/active", NULL, MS_BIND, NULL);
+}
+void ruri_set_default_command(struct RURI_CONTAINER *_Nonnull container)
+{
+	/*
+	 * Set default command for exec().
+	 */
+	if (container->command[0] != NULL) {
+		return;
+	}
+	if (su_biany_exist(container->container_dir) && container->user == NULL) {
+		container->command[0] = "/bin/su";
+		container->command[1] = "-";
+		container->command[2] = NULL;
+	} else {
+		container->command[0] = "/bin/sh";
+		container->command[1] = NULL;
+	}
+}
+void ruri_setup_timens(const struct RURI_CONTAINER *_Nonnull container)
+{
+	/*
+	 * Setup time namespace offsets.
+	 */
+	if (container->timens_monotonic_offset != 0) {
+		usleep(1000);
+		int fd = open("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
+		if (fd < 0) {
+			ruri_error("{red}Error: failed to open /proc/self/timens_offsets QwQ\n");
+		}
+		char buf[1024] = { '\0' };
+		sprintf(buf, _Generic((time_t)0, long: "monotonic %ld 0", long long: "monotonic %lld 0", default: "monotonic %ld 0"), container->timens_monotonic_offset);
+		write(fd, buf, strlen(buf));
+		close(fd);
+	}
+	if (container->timens_realtime_offset != 0) {
+		int fd = open("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
+		if (fd < 0) {
+			ruri_error("{red}Error: failed to open /proc/self/timens_offsets QwQ\n");
+		}
+		char buf[1024] = { '\0' };
+		sprintf(buf, _Generic((time_t)0, long: "boottime %ld 0", long long: "boottime %lld 0", default: "boottime %ld 0"), container->timens_realtime_offset);
+		write(fd, buf, strlen(buf));
+		close(fd);
+	}
+}
 static void set_oom_score(int score)
 {
 	/*
@@ -871,11 +936,7 @@ void ruri_run_chroot_container(struct RURI_CONTAINER *_Nonnull container)
 	set_hostname(container);
 	// Ignore SIGTTIN, if we are running in the background, SIGTTIN may kill this process.
 	if (!container->enable_tty_signals) {
-		sigset_t sigs;
-		sigemptyset(&sigs);
-		sigaddset(&sigs, SIGTTIN);
-		sigaddset(&sigs, SIGTTOU);
-		sigprocmask(SIG_BLOCK, &sigs, 0);
+		ruri_block_tty_signals();
 	}
 	// Check if system runtime files are already created.
 	// container_dir should bind-mount before chroot(2),
@@ -914,16 +975,7 @@ void ruri_run_chroot_container(struct RURI_CONTAINER *_Nonnull container)
 		}
 	}
 	// Set default command for exec().
-	if (container->command[0] == NULL) {
-		if (su_biany_exist(container->container_dir) && container->user == NULL) {
-			container->command[0] = "/bin/su";
-			container->command[1] = "-";
-			container->command[2] = NULL;
-		} else {
-			container->command[0] = "/bin/sh";
-			container->command[1] = NULL;
-		}
-	}
+	ruri_set_default_command(container);
 	// Check binary used.
 	check_binary(container);
 	// Set up cgroup limit on host.
@@ -1049,11 +1101,7 @@ void ruri_run_rootless_chroot_container(struct RURI_CONTAINER *_Nonnull containe
 	 */
 	// Ignore SIGTTIN, if we are running in the background, SIGTTIN may kill this process.
 	if (!container->enable_tty_signals) {
-		sigset_t sigs;
-		sigemptyset(&sigs);
-		sigaddset(&sigs, SIGTTIN);
-		sigaddset(&sigs, SIGTTOU);
-		sigprocmask(SIG_BLOCK, &sigs, 0);
+		ruri_block_tty_signals();
 	}
 	// Mount mountpoints.
 	mount_rootfs(container);
@@ -1065,20 +1113,12 @@ void ruri_run_rootless_chroot_container(struct RURI_CONTAINER *_Nonnull containe
 		mount(container->container_dir, container->container_dir, NULL, MS_BIND | MS_REMOUNT | MS_RDONLY, NULL);
 	}
 	// Set default command for exec().
+	ruri_set_default_command(container);
 	if (container->command[0] == NULL) {
-		if (su_biany_exist(container->container_dir) && container->user == NULL) {
-			container->command[0] = "/bin/su";
-			container->command[1] = "-";
+		if (busybox_exists(container->container_dir)) {
+			container->command[0] = "/bin/busybox";
+			container->command[1] = "sh";
 			container->command[2] = NULL;
-		} else {
-			if (busybox_exists(container->container_dir)) {
-				container->command[0] = "/bin/busybox";
-				container->command[1] = "sh";
-				container->command[2] = NULL;
-			} else {
-				container->command[0] = "/bin/sh";
-				container->command[1] = NULL;
-			}
 		}
 	}
 	// Check binary used.

--- a/src/config.c
+++ b/src/config.c
@@ -145,20 +145,18 @@ char *ruri_container_info_to_k2v(const struct RURI_CONTAINER *_Nonnull container
 	char *drop_caplist[RURI_CAP_LAST_CAP + 1] = { NULL };
 	int len = 0;
 #ifndef DISABLE_LIBCAP
-	char *cap_tmp = NULL;
 	for (int i = 0; true; i++) {
 		if (container->drop_caplist[i] == RURI_INIT_VALUE) {
 			len = i;
 			break;
 		}
-		cap_tmp = cap_to_name(container->drop_caplist[i]);
+		char *cap_tmp = cap_to_name(container->drop_caplist[i]);
 		if (cap_tmp == NULL) {
-			drop_caplist[i] = malloc(114);
-			sprintf(drop_caplist[i], "%d", container->drop_caplist[i]);
+			drop_caplist[i] = malloc(16);
+			snprintf(drop_caplist[i], 16, "%d", container->drop_caplist[i]);
 		} else {
 			drop_caplist[i] = strdup(cap_tmp);
 			cap_free(cap_tmp);
-			cap_tmp = NULL;
 		}
 	}
 #endif

--- a/src/include/ruri.h
+++ b/src/include/ruri.h
@@ -338,6 +338,19 @@ int ruri_get_groups(uid_t uid, gid_t groups[]);
 int ruri_cap_from_name(const char *str, cap_value_t *cap);
 #endif
 void ruri_clear_env(char *const *_Nonnull argv);
+void ruri_block_tty_signals(void);
+void ruri_setup_timens(const struct RURI_CONTAINER *_Nonnull container);
+void ruri_mask_proc_sys(const struct RURI_CONTAINER *_Nonnull container);
+void ruri_set_default_command(struct RURI_CONTAINER *_Nonnull container);
+void ruri_add_to_strarray(char *_Nonnull array[], int max, const char *_Nonnull str);
+void ruri_add_mount(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull source, const char *_Nonnull target, bool ro);
+void ruri_add_env(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull key, const char *_Nonnull value);
+void ruri_add_masked_path(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull path);
+void ruri_add_char_dev(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull name, int major, int minor);
+void ruri_add_seccomp_syscall(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull syscall);
+#ifndef DISABLE_LIBCAP
+void ruri_add_cap(cap_value_t caplist[], const char *_Nonnull cap_str);
+#endif
 // Bionic does not have memfd_create()
 #ifdef __ANDROID__
 #define memfd_create(...) syscall(SYS_memfd_create, __VA_ARGS__)

--- a/src/mount.c
+++ b/src/mount.c
@@ -188,14 +188,12 @@ static int mk_mountpoint_dir(const char *_Nonnull target)
 	// I know this can hardly be happen, just to avoid some unexpected errors.
 	remove(target);
 	// Check if mountpoint exists.
-	char *test = realpath(target, NULL);
-	if (test == NULL) {
-		if (ruri_mkdirs(target, S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH) != 0) {
-			return -1;
-		}
-	} else {
-		free(test);
+	struct stat st;
+	if (stat(target, &st) == 0) {
 		return 0;
+	}
+	if (ruri_mkdirs(target, S_IRGRP | S_IWGRP | S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH) != 0) {
+		return -1;
 	}
 	return 0;
 }

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -47,7 +47,10 @@ static char *line_get_username(const char *_Nonnull p)
 	 * Get username by line.
 	 * free() after use.
 	 */
-	char *ret = malloc(LOGIN_NAME_MAX * 4);
+	char *ret = malloc(LOGIN_NAME_MAX);
+	if (ret == NULL) {
+		return NULL;
+	}
 	ret[0] = '\0';
 	// /etc/passwd format:
 	// name:password:uid:gid:comment:home directory:login shell
@@ -57,7 +60,7 @@ static char *line_get_username(const char *_Nonnull p)
 		return ret;
 	}
 	// Read the username until we meet the first colon.
-	for (int i = 0; p[i] != '\0' && i < (LOGIN_NAME_MAX * 2); i++) {
+	for (int i = 0; p[i] != '\0' && i < (LOGIN_NAME_MAX - 1); i++) {
 		if (p[i] == ':') {
 			break;
 		}

--- a/src/rootless.c
+++ b/src/rootless.c
@@ -159,8 +159,7 @@ static void init_rootless_container(struct RURI_CONTAINER *_Nonnull container)
 	if (container->memory == NULL) {
 		devshm_options = strdup("mode=1777");
 	} else {
-		devshm_options = malloc(strlen(container->memory) + strlen("mode=1777") + 114);
-		sprintf(devshm_options, "size=65536k,mode=1777");
+		devshm_options = strdup("size=65536k,mode=1777");
 	}
 	mkdir("./dev/shm", S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH | S_IRGRP | S_IWGRP);
 	mount("tmpfs", "./dev/shm", "tmpfs", MS_NOSUID | MS_NOEXEC | MS_NODEV, devshm_options);
@@ -187,12 +186,12 @@ static void init_rootless_container(struct RURI_CONTAINER *_Nonnull container)
 		mount("/dev/null", "./proc/timer_list", "", MS_BIND, NULL);
 		mount("/dev/null", "./proc/timer_stats", "", MS_BIND, NULL);
 		mount("/dev/null", "./proc/sched_debug", "", MS_BIND, NULL);
-		mount("/dev/null", "/proc/sysrq-trigger", "", MS_BIND, NULL);
+		mount("/dev/null", "./proc/sysrq-trigger", "", MS_BIND, NULL);
 		mount("tmpfs", "./proc/scsi", "tmpfs", MS_RDONLY, NULL);
 		mount("tmpfs", "./sys/firmware", "tmpfs", MS_RDONLY, NULL);
 		mount("tmpfs", "./sys/devices/virtual/powercap", "tmpfs", MS_RDONLY, NULL);
 		mount("tmpfs", "./sys/block", "tmpfs", MS_RDONLY, NULL);
-		mount("tmpfs", "/sys/kernel/debug", "tmpfs", MS_RDONLY, NULL);
+		mount("tmpfs", "./sys/kernel/debug", "tmpfs", MS_RDONLY, NULL);
 		mount("tmpfs", "./sys/module", "tmpfs", MS_RDONLY, NULL);
 		mount("tmpfs", "./sys/class/net", "tmpfs", MS_RDONLY, NULL);
 		mount("tmpfs", "./sys/fs/cgroup", "tmpfs", MS_RDONLY, NULL);
@@ -420,21 +419,7 @@ void ruri_run_rootless_container(struct RURI_CONTAINER *_Nonnull container)
 				ruri_warn_on_error(1, 0, !container->no_warnings, "{yellow}Warning: seems that time namespace is not supported on this device QwQ{clear}\n");
 			}
 		}
-		if (container->timens_monotonic_offset != 0) {
-			usleep(1000);
-			int fd = open("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
-			char buf[1024] = { '\0' };
-			sprintf(buf, _Generic((time_t)0, long: "monotonic %ld 0", long long: "monotonic %lld 0", default: "monotonic %ld 0"), container->timens_monotonic_offset);
-			write(fd, buf, strlen(buf));
-			close(fd);
-		}
-		if (container->timens_realtime_offset != 0) {
-			int fd = open("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
-			char buf[1024] = { '\0' };
-			sprintf(buf, _Generic((time_t)0, long: "boottime %ld 0", long long: "boottime %lld 0", default: "boottime %ld 0"), container->timens_realtime_offset);
-			write(fd, buf, strlen(buf));
-			close(fd);
-		}
+		ruri_setup_timens(container);
 		if (unshare(CLONE_SYSVSEM) == -1) {
 			ruri_warn_on_error(1, 0, !container->no_warnings, "{yellow}Warning: seems that semaphore namespace is not supported on this device QwQ{clear}\n");
 		}

--- a/src/ruri.c
+++ b/src/ruri.c
@@ -102,12 +102,12 @@ static void check_container(const struct RURI_CONTAINER *_Nonnull container)
 		ruri_error("{red}Error: --arch and --qemu-path should be set at the same time QwQ\n");
 	}
 	for (int i = 0; container->extra_mountpoint[i] != NULL; i++) {
-		if (strlen(container->extra_mountpoint[i]) > PATH_MAX) {
+		if (strlen(container->extra_mountpoint[i]) >= PATH_MAX) {
 			ruri_error("{red}Error: mountpoint path is too long QwQ\n");
 		}
 	}
 	for (int i = 0; container->extra_ro_mountpoint[i] != NULL; i++) {
-		if (strlen(container->extra_ro_mountpoint[i]) > PATH_MAX) {
+		if (strlen(container->extra_ro_mountpoint[i]) >= PATH_MAX) {
 			ruri_error("{red}Error: mountpoint path is too long QwQ\n");
 		}
 	}
@@ -148,6 +148,7 @@ static void parse_cgroup_settings(const char *_Nonnull str, struct RURI_CONTAINE
 			ruri_error("{red}Error: cpupercent should be in range 1-100\n");
 		}
 	} else {
+		free(limit);
 		ruri_error("{red}Unknown cgroup option %s\n", str);
 	}
 }
@@ -171,6 +172,98 @@ static bool is_container_dir(char *dir)
 	}
 	return true;
 }
+static void add_to_strarray(char *_Nonnull array[], int max, const char *_Nonnull str)
+{
+	for (int i = 0; i < max; i++) {
+		if (array[i] == NULL) {
+			array[i] = strdup(str);
+			array[i + 1] = NULL;
+			return;
+		}
+		if (i == (max - 1)) {
+			ruri_error("{red}Too many items QwQ\n");
+		}
+	}
+}
+static void add_mount(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull source, const char *_Nonnull target, bool ro)
+{
+	char **arr = ro ? container->extra_ro_mountpoint : container->extra_mountpoint;
+	for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i += 3) {
+		if (arr[i] == NULL) {
+			arr[i] = strdup(source);
+			arr[i + 1] = strdup(target);
+			arr[i + 2] = NULL;
+			if (strcmp(target, "/") == 0) {
+				free(arr[i]);
+				free(arr[i + 1]);
+				arr[i] = NULL;
+				arr[i + 1] = NULL;
+				if (container->rootfs_source == NULL) {
+					container->rootfs_source = strdup(source);
+					if (ro) {
+						container->ro_root = true;
+					}
+				} else {
+					ruri_error("{red}You can only mount one source to / QwQ\n");
+				}
+			}
+			return;
+		}
+		if (i >= (RURI_MAX_MOUNTPOINTS - 3)) {
+			ruri_error("{red}Too many mountpoints QwQ\n");
+		}
+	}
+}
+static void add_env(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull key, const char *_Nonnull value)
+{
+	for (int i = 0; i < RURI_MAX_ENVS; i += 2) {
+		if (container->env[i] == NULL) {
+			container->env[i] = strdup(key);
+			container->env[i + 1] = strdup(value);
+			container->env[i + 2] = NULL;
+			return;
+		}
+		if (i >= (RURI_MAX_ENVS - 2)) {
+			ruri_error("{red}Too many envs QwQ\n");
+		}
+	}
+}
+static void add_masked_path(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull path)
+{
+	add_to_strarray(container->masked_path, RURI_MAX_MOUNTPOINTS, path);
+}
+static void add_char_dev(struct RURI_CONTAINER *_Nonnull container, const char *_Nonnull name, int major, int minor)
+{
+	for (int i = 0; i < RURI_MAX_CHAR_DEVS; i += 3) {
+		if (container->char_devs[i] == NULL) {
+			container->char_devs[i] = strdup(name);
+			container->char_devs[i + 1] = malloc(16);
+			container->char_devs[i + 2] = malloc(16);
+			sprintf(container->char_devs[i + 1], "%d", major);
+			sprintf(container->char_devs[i + 2], "%d", minor);
+			container->char_devs[i + 3] = NULL;
+			return;
+		}
+		if (i >= (RURI_MAX_CHAR_DEVS - 3)) {
+			ruri_error("{red}Too many char devices QwQ\n");
+		}
+	}
+}
+#ifndef DISABLE_LIBCAP
+static void add_cap(cap_value_t caplist[], const char *_Nonnull cap_str)
+{
+	if (atoi(cap_str) != 0) {
+		ruri_add_to_caplist(caplist, atoi(cap_str));
+	} else {
+		cap_value_t cap = RURI_INIT_VALUE;
+		if (ruri_cap_from_name(cap_str, &cap) == 0) {
+			ruri_add_to_caplist(caplist, cap);
+		} else {
+			ruri_error("{red}Error: unknown capability `%s`\nQwQ{clear}\n", cap_str);
+		}
+	}
+}
+#endif
 static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_Nonnull container)
 {
 	/*
@@ -193,7 +286,6 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 	char *output_path = NULL;
 	cap_value_t keep_caplist_extra[RURI_CAP_LAST_CAP + 1] = { RURI_INIT_VALUE };
 	cap_value_t drop_caplist_extra[RURI_CAP_LAST_CAP + 1] = { RURI_INIT_VALUE };
-	cap_value_t cap = RURI_INIT_VALUE;
 	bool privileged = false;
 	bool use_config_file = false;
 	bool background = false;
@@ -469,17 +561,7 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 		else if (strcmp(argv[index], "-Q") == 0 || strcmp(argv[index], "--mask-path") == 0) {
 			index++;
 			if (index < argc) {
-				for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i++) {
-					if (container->masked_path[i] == NULL) {
-						container->masked_path[i] = strdup(argv[index]);
-						container->masked_path[i + 1] = NULL;
-						break;
-					}
-					// Max 512 mountpoints.
-					if (i == (RURI_MAX_MOUNTPOINTS - 1)) {
-						ruri_error("{red}Too many masked paths QwQ\n");
-					}
-				}
+				add_masked_path(container, argv[index]);
 			} else {
 				ruri_error("{red}Unknown masked path QwQ\n");
 			}
@@ -488,19 +570,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 		else if (strcmp(argv[index], "-e") == 0 || strcmp(argv[index], "--env") == 0) {
 			index++;
 			if ((argv[index] != NULL) && (argv[index + 1] != NULL)) {
-				for (int i = 0; i < RURI_MAX_ENVS; i++) {
-					if (container->env[i] == NULL) {
-						container->env[i] = strdup(argv[index]);
-						index++;
-						container->env[i + 1] = strdup(argv[index]);
-						container->env[i + 2] = NULL;
-						break;
-					}
-					// Max 512 envs.
-					if (i == (RURI_MAX_ENVS - 1)) {
-						ruri_error("{red}Too many envs QwQ\n");
-					}
-				}
+				add_env(container, argv[index], argv[index + 1]);
+				index++;
 			} else {
 				ruri_error("{red}Error: unknown env QwQ\n");
 			}
@@ -512,30 +583,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 				if (strcmp(argv[index], "/") == 0) {
 					ruri_error("{red}/ is not allowed to use as a mountpoint QwQ\n");
 				}
-				for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i++) {
-					if (container->extra_mountpoint[i] == NULL) {
-						container->extra_mountpoint[i] = strdup(argv[index]);
-						index++;
-						container->extra_mountpoint[i + 1] = strdup(argv[index]);
-						if (strcmp(argv[index], "/") == 0) {
-							free(container->extra_mountpoint[i]);
-							free(container->extra_mountpoint[i + 1]);
-							container->extra_mountpoint[i] = NULL;
-							container->extra_mountpoint[i + 1] = NULL;
-							if (container->rootfs_source == NULL) {
-								container->rootfs_source = strdup(argv[index - 1]);
-							} else {
-								ruri_error("{red}You can only mount one source to / QwQ\n");
-							}
-						}
-						container->extra_mountpoint[i + 2] = NULL;
-						break;
-					}
-					// Max 512 mountpoints.
-					if (i == (RURI_MAX_MOUNTPOINTS - 1)) {
-						ruri_error("{red}Too many mountpoints QwQ\n");
-					}
-				}
+				add_mount(container, argv[index], argv[index + 1], false);
+				index++;
 			} else {
 				ruri_error("{red}Error: unknown mountpoint QwQ\n");
 			}
@@ -544,31 +593,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 		else if (strcmp(argv[index], "-M") == 0 || strcmp(argv[index], "--ro-mount") == 0) {
 			index++;
 			if ((argv[index] != NULL) && (argv[index + 1] != NULL)) {
-				for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i++) {
-					if (container->extra_ro_mountpoint[i] == NULL) {
-						container->extra_ro_mountpoint[i] = strdup(argv[index]);
-						index++;
-						container->extra_ro_mountpoint[i + 1] = strdup(argv[index]);
-						container->extra_ro_mountpoint[i + 2] = NULL;
-						if (strcmp(argv[index], "/") == 0) {
-							free(container->extra_ro_mountpoint[i]);
-							free(container->extra_ro_mountpoint[i + 1]);
-							container->extra_ro_mountpoint[i] = NULL;
-							container->extra_ro_mountpoint[i + 1] = NULL;
-							if (container->rootfs_source == NULL) {
-								container->rootfs_source = strdup(argv[index - 1]);
-								container->ro_root = true;
-							} else {
-								ruri_error("{red}You can only mount one source to / QwQ\n");
-							}
-						}
-						break;
-					}
-					// Max 512 mountpoints.
-					if (i == (RURI_MAX_MOUNTPOINTS - 1)) {
-						ruri_error("{red}Too many mountpoints QwQ\n");
-					}
-				}
+				add_mount(container, argv[index], argv[index + 1], true);
+				index++;
 			} else {
 				ruri_error("{red}Error: unknown mountpoint QwQ\n");
 			}
@@ -577,45 +603,27 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 		else if (strcmp(argv[index], "-I") == 0 || strcmp(argv[index], "--char-dev") == 0) {
 			index++;
 			if ((argv[index] != NULL) && (argv[index + 1] != NULL) && (argv[index + 2] != NULL)) {
-				for (int i = 0; i < RURI_MAX_CHAR_DEVS; i++) {
-					if (container->char_devs[i] == NULL) {
-						container->char_devs[i] = strdup(argv[index]);
-						index++;
-						if (atoi(argv[index]) < 0) {
-							ruri_error("{red}Error: invalid major number QwQ\n");
-						}
-						container->char_devs[i + 1] = strdup(argv[index]);
-						index++;
-						if (atoi(argv[index]) <= 0 && strcmp(argv[index], "0") != 0) {
-							ruri_error("{red}Error: invalid minor number QwQ\n");
-						}
-						container->char_devs[i + 2] = strdup(argv[index]);
-						container->char_devs[i + 3] = NULL;
-						// If major is 0, we will auto-detect the major and minor number from the host device.
-						if (atoi(container->char_devs[i + 1]) == 0) {
-							free(container->char_devs[i + 1]);
-							free(container->char_devs[i + 2]);
-							char dev_path[PATH_MAX];
-							sprintf(dev_path, "/dev/%s", container->char_devs[i]);
-							struct stat st;
-							if (stat(dev_path, &st) != 0) {
-								ruri_error("{red}Error: device %s does not exist on host QwQ\n", dev_path);
-							}
-							if (!S_ISCHR(st.st_mode)) {
-								ruri_error("{red}Error: device %s is not a char device on host QwQ\n", dev_path);
-							}
-							container->char_devs[i + 1] = malloc(16);
-							container->char_devs[i + 2] = malloc(16);
-							sprintf(container->char_devs[i + 1], "%d", major(st.st_rdev));
-							sprintf(container->char_devs[i + 2], "%d", minor(st.st_rdev));
-							ruri_log("{base}Auto-detected char device: %s (major: %s, minor: %s)\n", container->char_devs[i], container->char_devs[i + 1], container->char_devs[i + 2]);
-						}
-						break;
-					}
-					if (i == (RURI_MAX_CHAR_DEVS - 1)) {
-						ruri_error("{red}Too many char devices QwQ\n");
-					}
+				int major_num = atoi(argv[index + 1]);
+				int minor_num = atoi(argv[index + 2]);
+				if (major_num < 0) {
+					ruri_error("{red}Error: invalid major number QwQ\n");
 				}
+				if (major_num == 0) {
+					char dev_path[PATH_MAX];
+					sprintf(dev_path, "/dev/%s", argv[index]);
+					struct stat st;
+					if (stat(dev_path, &st) != 0) {
+						ruri_error("{red}Error: device %s does not exist on host QwQ\n", dev_path);
+					}
+					if (!S_ISCHR(st.st_mode)) {
+						ruri_error("{red}Error: device %s is not a char device on host QwQ\n", dev_path);
+					}
+					major_num = major(st.st_rdev);
+					minor_num = minor(st.st_rdev);
+					ruri_log("{base}Auto-detected char device: %s (major: %d, minor: %d)\n", argv[index], major_num, minor_num);
+				}
+				add_char_dev(container, argv[index], major_num, minor_num);
+				index += 2;
 			} else {
 				ruri_error("{red}Error: unknown char devices QwQ\n");
 			}
@@ -625,16 +633,7 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 #ifndef DISABLE_LIBSECCOMP
 			index++;
 			if (argv[index] != NULL) {
-				for (int i = 0; i < RURI_MAX_SECCOMP_DENIED_SYSCALL; i++) {
-					if (container->seccomp_denied_syscall[i] == NULL) {
-						container->seccomp_denied_syscall[i] = strdup(argv[index]);
-						container->seccomp_denied_syscall[i + 1] = NULL;
-						break;
-					}
-					if (i == (RURI_MAX_SECCOMP_DENIED_SYSCALL - 1)) {
-						ruri_error("{red}Too many syscalls QwQ\n");
-					}
-				}
+				add_to_strarray(container->seccomp_denied_syscall, RURI_MAX_SECCOMP_DENIED_SYSCALL, argv[index]);
 			} else {
 				ruri_error("{red}Error: unknown syscall QwQ\n");
 			}
@@ -663,17 +662,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 #ifndef DISABLE_LIBCAP
 			index++;
 			if (argv[index] != NULL) {
-				// We both support capability name and number,
-				// because in the fulture, there might be new capabilities that
-				// we can not use the name to match it in current libcap.
-				if (atoi(argv[index]) != 0) {
-					ruri_add_to_caplist(keep_caplist_extra, atoi(argv[index]));
-				} else if (ruri_cap_from_name(argv[index], &cap) == 0) {
-					ruri_add_to_caplist(keep_caplist_extra, cap);
-					ruri_log("{base}Keep capability: %s\n", argv[index]);
-				} else {
-					ruri_error("{red}or: unknown capability `%s`\nQwQ{clear}\n", argv[index]);
-				}
+				add_cap(keep_caplist_extra, argv[index]);
+				ruri_log("{base}Keep capability: %s\n", argv[index]);
 			} else {
 				ruri_error("{red}Missing argument\n");
 			}
@@ -686,13 +676,7 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 #ifndef DISABLE_LIBCAP
 			index++;
 			if (argv[index] != NULL) {
-				if (atoi(argv[index]) != 0) {
-					ruri_add_to_caplist(drop_caplist_extra, atoi(argv[index]));
-				} else if (cap_from_name(argv[index], &cap) == 0) {
-					ruri_add_to_caplist(drop_caplist_extra, cap);
-				} else {
-					ruri_error("{red}Error: unknown capability `%s`\nQwQ{clear}\n", argv[index]);
-				}
+				add_cap(drop_caplist_extra, argv[index]);
 			} else {
 				ruri_error("{red}Missing argument\n");
 			}
@@ -899,17 +883,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 					if (i == (strlen(argv[index]) - 1)) {
 						index++;
 						if (argv[index] != NULL) {
-							// We both support capability name and number,
-							// because in the fulture, there might be new capabilities that
-							// we can not use the name to match it in current libcap.
-							if (atoi(argv[index]) != 0) {
-								ruri_add_to_caplist(keep_caplist_extra, atoi(argv[index]));
-							} else if (ruri_cap_from_name(argv[index], &cap) == 0) {
-								ruri_add_to_caplist(keep_caplist_extra, cap);
-								ruri_log("{base}Keep capability: %s\n", argv[index]);
-							} else {
-								ruri_error("{red}or: unknown capability `%s`\nQwQ{clear}\n", argv[index]);
-							}
+							add_cap(keep_caplist_extra, argv[index]);
+							ruri_log("{base}Keep capability: %s\n", argv[index]);
 						} else {
 							ruri_error("{red}Missing argument\n");
 						}
@@ -925,13 +900,7 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 					if (i == (strlen(argv[index]) - 1)) {
 						index++;
 						if (argv[index] != NULL) {
-							if (atoi(argv[index]) != 0) {
-								ruri_add_to_caplist(drop_caplist_extra, atoi(argv[index]));
-							} else if (ruri_cap_from_name(argv[index], &cap) == 0) {
-								ruri_add_to_caplist(drop_caplist_extra, cap);
-							} else {
-								ruri_error("{red}Error: unknown capability `%s`\nQwQ{clear}\n", argv[index]);
-							}
+							add_cap(drop_caplist_extra, argv[index]);
 						} else {
 							ruri_error("{red}Missing argument\n");
 						}
@@ -946,19 +915,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 					if (i == (strlen(argv[index]) - 1)) {
 						index++;
 						if ((argv[index] != NULL) && (argv[index + 1] != NULL)) {
-							for (int i = 0; i < RURI_MAX_ENVS; i++) {
-								if (container->env[i] == NULL) {
-									container->env[i] = strdup(argv[index]);
-									index++;
-									container->env[i + 1] = strdup(argv[index]);
-									container->env[i + 2] = NULL;
-									break;
-								}
-								// Max 512 envs.
-								if (i == (RURI_MAX_ENVS - 1)) {
-									ruri_error("{red}Too many envs QwQ\n");
-								}
-							}
+							add_env(container, argv[index], argv[index + 1]);
+							index++;
 						} else {
 							ruri_error("{red}Error: unknown env QwQ\n");
 						}
@@ -973,30 +931,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 							if (strcmp(argv[index], "/") == 0) {
 								ruri_error("{red}/ is not allowed to use as a mountpoint QwQ\n");
 							}
-							for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i++) {
-								if (container->extra_mountpoint[i] == NULL) {
-									container->extra_mountpoint[i] = strdup(argv[index]);
-									index++;
-									container->extra_mountpoint[i + 1] = strdup(argv[index]);
-									if (strcmp(argv[index], "/") == 0) {
-										free(container->extra_mountpoint[i]);
-										free(container->extra_mountpoint[i + 1]);
-										container->extra_mountpoint[i] = NULL;
-										container->extra_mountpoint[i + 1] = NULL;
-										if (container->rootfs_source == NULL) {
-											container->rootfs_source = strdup(argv[index - 1]);
-										} else {
-											ruri_error("{red}You can only mount one source to / QwQ\n");
-										}
-									}
-									container->extra_mountpoint[i + 2] = NULL;
-									break;
-								}
-								// Max 512 mountpoints.
-								if (i == (RURI_MAX_MOUNTPOINTS - 1)) {
-									ruri_error("{red}Too many mountpoints QwQ\n");
-								}
-							}
+							add_mount(container, argv[index], argv[index + 1], false);
+							index++;
 						} else {
 							ruri_error("{red}Error: unknown mountpoint QwQ\n");
 						}
@@ -1008,31 +944,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 					if (i == (strlen(argv[index]) - 1)) {
 						index++;
 						if ((argv[index] != NULL) && (argv[index + 1] != NULL)) {
-							for (int i = 0; i < RURI_MAX_MOUNTPOINTS; i++) {
-								if (container->extra_ro_mountpoint[i] == NULL) {
-									container->extra_ro_mountpoint[i] = strdup(argv[index]);
-									index++;
-									container->extra_ro_mountpoint[i + 1] = strdup(argv[index]);
-									container->extra_ro_mountpoint[i + 2] = NULL;
-									if (strcmp(argv[index], "/") == 0) {
-										free(container->extra_ro_mountpoint[i]);
-										free(container->extra_ro_mountpoint[i + 1]);
-										container->extra_ro_mountpoint[i] = NULL;
-										container->extra_ro_mountpoint[i + 1] = NULL;
-										if (container->rootfs_source == NULL) {
-											container->rootfs_source = strdup(argv[index - 1]);
-											container->ro_root = true;
-										} else {
-											ruri_error("{red}You can only mount one source to / QwQ\n");
-										}
-									}
-									break;
-								}
-								// Max 512 mountpoints.
-								if (i == (RURI_MAX_MOUNTPOINTS - 1)) {
-									ruri_error("{red}Too many mountpoints QwQ\n");
-								}
-							}
+							add_mount(container, argv[index], argv[index + 1], true);
+							index++;
 						} else {
 							ruri_error("{red}Error: unknown mountpoint QwQ\n");
 						}
@@ -1184,16 +1097,7 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 							ruri_error("{red}Please specify the syscall\n{clear}");
 						}
 						index++;
-						for (int i = 0; i < RURI_MAX_SECCOMP_DENIED_SYSCALL; i++) {
-							if (container->seccomp_denied_syscall[i] == NULL) {
-								container->seccomp_denied_syscall[i] = strdup(argv[index]);
-								container->seccomp_denied_syscall[i + 1] = NULL;
-								break;
-							}
-							if (i == (RURI_MAX_SECCOMP_DENIED_SYSCALL - 1)) {
-								ruri_error("{red}Too many syscalls QwQ\n");
-							}
-						}
+						add_to_strarray(container->seccomp_denied_syscall, RURI_MAX_SECCOMP_DENIED_SYSCALL, argv[index]);
 					} else {
 						ruri_error("Invalid argument %s\n", argv[index]);
 					}
@@ -1243,11 +1147,7 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 			exit(EXIT_SUCCESS);
 		}
 		// Ignore SIGTTIN, we are now running in the background, SIGTTIN may kill this process.
-		sigset_t sigs;
-		sigemptyset(&sigs);
-		sigaddset(&sigs, SIGTTIN);
-		sigaddset(&sigs, SIGTTOU);
-		sigprocmask(SIG_BLOCK, &sigs, 0);
+		ruri_block_tty_signals();
 		// Redirect stdout and stderr to log file or /dev/null.
 		if (log_file != NULL) {
 			ruri_mkdirs(log_file, 0755);

--- a/src/rurienv.c
+++ b/src/rurienv.c
@@ -119,20 +119,18 @@ static char *build_container_info(const struct RURI_CONTAINER *_Nonnull containe
 // drop_caplist.
 #ifndef DISABLE_LIBCAP
 	char *drop_caplist[RURI_CAP_LAST_CAP + 1] = { NULL };
-	char *cap_tmp = NULL;
 	for (int i = 0; true; i++) {
 		if (container->drop_caplist[i] == RURI_INIT_VALUE) {
 			len = i;
 			break;
 		}
-		cap_tmp = cap_to_name(container->drop_caplist[i]);
+		char *cap_tmp = cap_to_name(container->drop_caplist[i]);
 		if (cap_tmp == NULL) {
-			drop_caplist[i] = malloc(114);
-			sprintf(drop_caplist[i], "%d", container->drop_caplist[i]);
+			drop_caplist[i] = malloc(16);
+			snprintf(drop_caplist[i], 16, "%d", container->drop_caplist[i]);
 		} else {
 			drop_caplist[i] = strdup(cap_tmp);
 			cap_free(cap_tmp);
-			cap_tmp = NULL;
 		}
 	}
 	ret = k2v_add_comment(ret, "The capability to drop.");
@@ -268,6 +266,10 @@ void ruri_store_info(const struct RURI_CONTAINER *_Nonnull container)
 	}
 	// Creat .rurienv file and open it.
 	fd = open(file, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, S_IWUSR | S_IRUSR);
+	if (fd < 0) {
+		free(info);
+		ruri_error("{red}Error: failed to create .rurienv file QwQ\n");
+	}
 	// Write info to .rurienv file.
 	write(fd, info, strlen(info));
 	// Set immutable flag on .rurienv file.
@@ -350,13 +352,13 @@ struct RURI_CONTAINER *ruri_read_info(struct RURI_CONTAINER *_Nullable container
 		int fd = open(file, O_RDONLY | O_CLOEXEC);
 		if (fd < 0 && !container->no_warnings) {
 			ruri_warning("{yellow}Open .rurienv failed{clear}\n");
+		} else {
+			int attr = 0;
+			ioctl(fd, FS_IOC_GETFLAGS, &attr);
+			attr &= ~FS_IMMUTABLE_FL;
+			ioctl(fd, FS_IOC_SETFLAGS, &attr);
+			close(fd);
 		}
-		int attr = 0;
-		ioctl(fd, FS_IOC_GETFLAGS, &attr);
-		attr &= ~FS_IMMUTABLE_FL;
-		ioctl(fd, FS_IOC_SETFLAGS, &attr);
-		remove(file);
-		close(fd);
 		remove(file);
 		return container;
 	}

--- a/src/signal.c
+++ b/src/signal.c
@@ -43,8 +43,11 @@ static void panic(int sig)
 	signal(sig, SIG_DFL);
 	int clifd = open("/proc/self/cmdline", O_RDONLY | O_CLOEXEC);
 	char buf[1024];
-	ssize_t bufsize = read(clifd, buf, sizeof(buf));
-	close(clifd);
+	ssize_t bufsize = 0;
+	if (clifd >= 0) {
+		bufsize = read(clifd, buf, sizeof(buf));
+		close(clifd);
+	}
 	cfprintf(stderr, "{base}");
 	cfprintf(stderr, "{base}%s\n", "  .^.   .^.");
 	cfprintf(stderr, "{base}%s\n", "  /⋀\\_ﾉ_/⋀\\");

--- a/src/unshare.c
+++ b/src/unshare.c
@@ -64,27 +64,7 @@ static pid_t init_unshare_container(struct RURI_CONTAINER *_Nonnull container)
 		}
 		ruri_warn_on_error(1, 0, !container->no_warnings, "{yellow}Warning: seems that time namespace is not supported on this device QwQ{clear}\n");
 	}
-	if (container->timens_monotonic_offset != 0) {
-		usleep(1000);
-		int fd = open("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
-		if (fd < 0) {
-			ruri_error("{red}Error: failed to open /proc/self/timens_offsets QwQ\n");
-		}
-		char buf[1024] = { '\0' };
-		sprintf(buf, _Generic((time_t)0, long: "monotonic %ld 0", long long: "monotonic %lld 0", default: "monotonic %ld 0"), container->timens_monotonic_offset);
-		write(fd, buf, strlen(buf));
-		close(fd);
-	}
-	if (container->timens_realtime_offset != 0) {
-		int fd = open("/proc/self/timens_offsets", O_WRONLY | O_CLOEXEC);
-		if (fd < 0) {
-			ruri_error("{red}Error: failed to open /proc/self/timens_offsets QwQ\n");
-		}
-		char buf[1024] = { '\0' };
-		sprintf(buf, _Generic((time_t)0, long: "boottime %ld 0", long long: "boottime %lld 0", default: "boottime %ld 0"), container->timens_realtime_offset);
-		write(fd, buf, strlen(buf));
-		close(fd);
-	}
+	ruri_setup_timens(container);
 	unshare_ret = unshare(CLONE_FILES);
 	ruri_warn_on_error(unshare_ret, 0, !container->no_warnings, "{yellow}Warning: seems that we could not unshare file descriptors with child process QwQ{clear}\n");
 	unshare_ret = unshare(CLONE_FS);


### PR DESCRIPTION
This commit performs code deduplication and security hardening:

New exported APIs (src/include/ruri.h):
- ruri_block_tty_signals()     -- block SIGTTIN/SIGTTOU
- ruri_setup_timens()          -- configure time namespace offsets
- ruri_mask_proc_sys()         -- mask sensitive /proc and /sys paths
- ruri_set_default_command()   -- set default exec command

Internal helpers in ruri.c:
- add_to_strarray()            -- generic NULL-terminated string array append
- add_mount()                  -- unified mountpoint registration (ro/rw)
- add_env()                    -- unified env var registration
- add_masked_path()            -- wrapper for masked paths
- add_char_dev()               -- unified char device registration
- add_cap()                    -- unified capability parsing (name or number)

Code deduplication:
- Eliminate duplicated timens setup in unshare.c and rootless.c (~40 lines)
- Eliminate duplicated SIGTTIN/SIGTTOU blocking in 3 locations
- Eliminate duplicated proc/sys masking between chroot.c and rootless.c
- Eliminate duplicated default command logic in 2 functions
- Eliminate duplicated array-append loops for mountpoints, envs, masked paths, char devs, seccomp syscalls, and capabilities in both long-option and BSD short-option parsers (~200 lines)

Security fixes:
- mount.c: replace realpath()+mkdir() TOCTOU with stat()+mkdir()
- ruri.c: fix off-by-one path length check (>= PATH_MAX instead of >)
- ruri.c: fix memory leak on unknown cgroup option (free limit string)
- passwd.c: fix buffer size (LOGIN_NAME_MAX*4 -> LOGIN_NAME_MAX) and loop bound (LOGIN_NAME_MAX*2 -> LOGIN_NAME_MAX-1)
- chroot.c: add O_EXCL to /etc/machine-id open() to prevent symlink hijacking
- rootless.c: fix inconsistent path prefixes (/proc/sysrq-trigger and /sys/kernel/debug missing ./ prefix in rootless mode)