### PR TITLE
fix(config): initialize container struct in ruri_correct_config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -585,6 +585,7 @@ void ruri_correct_config(const char *_Nonnull path)
 		ruri_error("{red}Invalid config file, there is no key:container_dir\n{clear}");
 	}
 	struct RURI_CONTAINER container;
+	ruri_init_config(&container);
 	container.container_dir = k2v_get_key(char, "container_dir", buf);
 #ifndef DISABLE_LIBCAP
 	if (!have_key("drop_caplist", buf)) {


### PR DESCRIPTION
ruri_correct_config() declared a local struct RURI_CONTAINER without calling ruri_init_config(), then only filled a subset of fields via have_key()/k2v_get_key() branches. The remaining fields (char_devs, extra_mountpoint arrays, masked_path, etc.) kept stack garbage, so the final ruri_container_info_to_k2v() call walked uninitialized pointer arrays until it hit an unreadable address and crashed with SIGSEGV.

Calling ruri_init_config() right after the declaration brings this function in line with parse_args() (which calls ruri_init_config before its parse loop) and ruri_read_config() (which assumes an already- initialized container).

Reproduced on main: `ruri -C config` on a valid but partial k2v3 config (e.g. only container_dir/cpuset/memory/cpupercent set) reliably SIGSEGVs and, worse, unlinks the input file before panicking, so the original config is destroyed.

Verified after fix: -C on the same partial config exits 0 and writes a fully populated k2v3 config; a second -C on the result round-trips with no warnings.