### PR TITLE
fix(pidfile): wait for daemon to flush terminal state to pid file

### DIFF
--- a/src/watchdog.c
+++ b/src/watchdog.c
@@ -82,6 +82,24 @@ void ruri_pid_file_write(enum RURI_PID_FILE_REQ req, long long arg)
 		return;
 	}
 	write(ruri_pid_file_fd(-1), buf, strlen(buf));
+	// For terminal states (exited/signaled/unknown/panic), give the pid_file
+	// daemon time to flush the value to the pid file before we exit()/close
+	// the write end. Without this, the parent process (e.g. test_pid_file)
+	// can observe the stale RURI_INIT_* value the daemon wrote at startup,
+	// because the daemon is a double-forked orphan that may not have been
+	// scheduled to read() the socket yet.
+	switch (req) {
+	case RURI_PID_FILE_EXITED:
+	case RURI_PID_FILE_SIGNALED:
+	case RURI_PID_FILE_UNKNOWN:
+	case RURI_PID_FILE_PANIC_EXEC:
+	case RURI_PID_FILE_PANIC_INTERNAL:
+	case RURI_PID_FILE_PANIC_TIMEOUT:
+		usleep(100000); // 0.1s
+		break;
+	default:
+		break;
+	}
 }
 void ruri_setup_timeout_watchdog(const struct RURI_CONTAINER *_Nonnull container)
 {


### PR DESCRIPTION
ruri_pid_file_write() writes to a socketpair and returns immediately; the actual pid file (memfd) update happens in a double-forked daemon that reads the socket asynchronously. The caller then exits right away, closing the write end of the socket.

There is a window between the daemon writing its initial RURI_INIT_* probe and it read()ing the terminal status (RURI_EXITED_*/SIGNALED_*/ UNKNOWN/PANIC_*) from the socket. If the caller exits and its parent (e.g. test/test_pid_file.c) reads the pid file within that window, it sees the stale RURI_INIT_* value instead of the real exit status.

Reproduced as a flaky test #10 subtest #2 on CI (Got: <empty>/RURI_INIT_* instead of RURI_EXITED_1). Locally the race triggers ~8-10% of the time on both main and the cgroup branch (this bug predates the cgroup work): running `./test_pid_file RURI_EXITED_1 ./test false` 50x in a loop fails 4-5 times on stock main, and 0/100 after this fix.

Fix: in ruri_pid_file_write(), usleep(0.1s) after writing a terminal state so the daemon is reliably scheduled to flush it to the pid file. This mirrors the existing usleep-based synchronization already used in the auto-umount paths of the same daemon.