### PR TITLE
fix: address memory safety and signal handling issues

### DIFF
--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -436,7 +436,7 @@ static void ruri_set_cpuset(const struct RURI_CONTAINER *_Nonnull container, con
 		char cgroup_cpuset_cpus_path[PATH_MAX] = "";
 		sprintf(cgroup_cpuset_cpus_path, "%s%d/cpuset.cpus", cg_env->cpuset.prefix, container->container_id);
 		char buf[256] = "";
-		sprintf(buf, "%s\n", container->cpuset);
+		snprintf(buf, sizeof(buf), "%s\n", container->cpuset);
 		if (open_and_write(cgroup_cpuset_cpus_path, buf)) {
 			ruri_warn_on_error(1, 0, !ruri_flag("disable_warnings"), "{red}Failed to set cgroup v2 cpuset limit for %s\n", cgroup_cpuset_cpus_path);
 			return;
@@ -453,7 +453,7 @@ static void ruri_set_cpuset(const struct RURI_CONTAINER *_Nonnull container, con
 		char cgroup_cpuset_cpus_path[PATH_MAX] = "";
 		sprintf(cgroup_cpuset_cpus_path, "%s%d/cpuset.cpus", cg_env->cpuset.prefix, container->container_id);
 		char buf[256] = "";
-		sprintf(buf, "%s\n", container->cpuset);
+		snprintf(buf, sizeof(buf), "%s\n", container->cpuset);
 		if (open_and_write(cgroup_cpuset_cpus_path, buf)) {
 			ruri_warn_on_error(1, 0, !ruri_flag("disable_warnings"), "{red}Failed to set cgroup v1 cpuset limit for %s\n", cgroup_cpuset_cpus_path);
 			return;
@@ -638,10 +638,11 @@ static void ruri_set_io(const struct RURI_CONTAINER *_Nonnull container, const s
 	// Set I/O limit for our cgroup.
 	if (cg_env->io.type == RURI_CGROUP_V2) {
 		char cgroup_io_max_path[PATH_MAX] = "";
-		sprintf(cgroup_io_max_path, "%s%d/io.max", cg_env->io.prefix, container->container_id);
+		snprintf(cgroup_io_max_path, sizeof(cgroup_io_max_path), "%s%d/io.max", cg_env->io.prefix, container->container_id);
 		char buf[1024] = "";
+		size_t buf_off = 0;
 		// Format: "major:minor rbps=xxx wbps=xxx"
-		sprintf(buf, "%s", container->io_device);
+		buf_off += (size_t)snprintf(buf, sizeof(buf), "%s", container->io_device);
 		if (container->io_rbps != NULL) {
 			ssize_t rbps = humansize_to_bytes(container->io_rbps);
 			// NOLINTBEGIN
@@ -652,7 +653,9 @@ static void ruri_set_io(const struct RURI_CONTAINER *_Nonnull container, const s
 				ruri_error("I/O rbps value too big to current platform\n");
 			}
 			// NOLINTEND
-			sprintf(buf + strlen(buf), " rbps=%zd", rbps);
+			if (buf_off < sizeof(buf)) {
+				buf_off += (size_t)snprintf(buf + buf_off, sizeof(buf) - buf_off, " rbps=%zd", rbps);
+			}
 		}
 		if (container->io_wbps != NULL) {
 			ssize_t wbps = humansize_to_bytes(container->io_wbps);
@@ -664,9 +667,13 @@ static void ruri_set_io(const struct RURI_CONTAINER *_Nonnull container, const s
 				ruri_error("I/O wbps value too big to current platform\n");
 			}
 			// NOLINTEND
-			sprintf(buf + strlen(buf), " wbps=%zd", wbps);
+			if (buf_off < sizeof(buf)) {
+				buf_off += (size_t)snprintf(buf + buf_off, sizeof(buf) - buf_off, " wbps=%zd", wbps);
+			}
 		}
-		sprintf(buf + strlen(buf), "\n");
+		if (buf_off < sizeof(buf)) {
+			snprintf(buf + buf_off, sizeof(buf) - buf_off, "\n");
+		}
 		if (open_and_write(cgroup_io_max_path, buf)) {
 			ruri_warn_on_error(1, 0, !ruri_flag("disable_warnings"), "{red}Failed to set cgroup v2 I/O limit for %s\n", cgroup_io_max_path);
 			return;
@@ -685,7 +692,7 @@ static void ruri_set_io(const struct RURI_CONTAINER *_Nonnull container, const s
 			}
 			// NOLINTEND
 			char buf[1024] = "";
-			sprintf(buf, "%s %zd\n", container->io_device, rbps);
+			snprintf(buf, sizeof(buf), "%s %zd\n", container->io_device, rbps);
 			if (open_and_write(cgroup_blkio_read_path, buf)) {
 				ruri_warn_on_error(1, 0, !ruri_flag("disable_warnings"), "{red}Failed to set cgroup v1 I/O read limit for %s\n", cgroup_blkio_read_path);
 				return;
@@ -704,7 +711,7 @@ static void ruri_set_io(const struct RURI_CONTAINER *_Nonnull container, const s
 			}
 			// NOLINTEND
 			char buf[1024] = "";
-			sprintf(buf, "%s %zd\n", container->io_device, wbps);
+			snprintf(buf, sizeof(buf), "%s %zd\n", container->io_device, wbps);
 			if (open_and_write(cgroup_blkio_write_path, buf)) {
 				ruri_warn_on_error(1, 0, !ruri_flag("disable_warnings"), "{red}Failed to set cgroup v1 I/O write limit for %s\n", cgroup_blkio_write_path);
 				return;

--- a/src/chroot.c
+++ b/src/chroot.c
@@ -280,6 +280,9 @@ static void init_container(struct RURI_CONTAINER *_Nonnull container)
 			devshm_options = strdup("size=65536k,mode=1777");
 		} else {
 			devshm_options = malloc(strlen(container->memory) + strlen("mode=1777") + 114);
+			if (devshm_options == NULL) {
+				ruri_error("{red}Error: malloc() failed QwQ\n");
+			}
 			sprintf(devshm_options, "size=%s,mode=1777", container->memory);
 		}
 		res = mkdir("/dev/shm", S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH | S_IRGRP | S_IWGRP);
@@ -479,6 +482,9 @@ static void mount_host_runtime(const struct RURI_CONTAINER *_Nonnull container)
 		devshm_options = strdup("mode=1777");
 	} else {
 		devshm_options = malloc(strlen(container->memory) + strlen("mode=1777") + 114);
+		if (devshm_options == NULL) {
+			ruri_error("{red}Error: malloc() failed QwQ\n");
+		}
 		sprintf(devshm_options, "size=%s,mode=1777", container->memory);
 	}
 	memset(buf, '\0', sizeof(buf));
@@ -521,6 +527,11 @@ static void drop_caps(const struct RURI_CONTAINER *_Nonnull container)
 	// hrdp and datap are two pointers, so we malloc() to apply the memory for it first.
 	cap_user_header_t hrdp = (cap_user_header_t)malloc(sizeof(*hrdp));
 	cap_user_data_t datap = (cap_user_data_t)malloc(sizeof(*datap) * 10);
+	if (hrdp == NULL || datap == NULL) {
+		free(hrdp);
+		free(datap);
+		ruri_error("{red}Error: malloc() failed QwQ\n");
+	}
 	hrdp->pid = getpid();
 	hrdp->version = _LINUX_CAPABILITY_VERSION_3;
 	capget(hrdp, datap);
@@ -622,6 +633,9 @@ static void mount_mountpoints(const struct RURI_CONTAINER *_Nonnull container)
 		}
 		// Set the mountpoint to mount.
 		mountpoint_dir = (char *)malloc(strlen(container->extra_mountpoint[i + 1]) + strlen(container->container_dir) + 2);
+		if (mountpoint_dir == NULL) {
+			ruri_error("{red}Error: malloc() failed QwQ\n");
+		}
 		strcpy(mountpoint_dir, container->container_dir);
 		strcat(mountpoint_dir, container->extra_mountpoint[i + 1]);
 		if (ruri_trymount(container->extra_mountpoint[i], mountpoint_dir, 0) != 0) {
@@ -636,6 +650,9 @@ static void mount_mountpoints(const struct RURI_CONTAINER *_Nonnull container)
 		}
 		// Set the mountpoint to mount.
 		mountpoint_dir = (char *)malloc(strlen(container->extra_ro_mountpoint[i + 1]) + strlen(container->container_dir) + 2);
+		if (mountpoint_dir == NULL) {
+			ruri_error("{red}Error: malloc() failed QwQ\n");
+		}
 		strcpy(mountpoint_dir, container->container_dir);
 		strcat(mountpoint_dir, container->extra_ro_mountpoint[i + 1]);
 		if (ruri_trymount(container->extra_ro_mountpoint[i], mountpoint_dir, MS_RDONLY) != 0) {
@@ -759,6 +776,9 @@ static void change_user(const struct RURI_CONTAINER *_Nonnull container)
 	if (atoi(user) > 0) {
 		int groups_count = 0;
 		gid_t *groups = malloc(NGROUPS_MAX * sizeof(gid_t));
+		if (groups == NULL) {
+			ruri_error("{red}Error: malloc() failed QwQ\n");
+		}
 		groups_count = ruri_get_groups((uid_t)atoi(user), groups);
 		if (groups_count > 0) {
 			res = setgroups((size_t)groups_count, groups);
@@ -783,6 +803,9 @@ static void change_user(const struct RURI_CONTAINER *_Nonnull container)
 		} else {
 			int groups_count = 0;
 			gid_t *groups = malloc(NGROUPS_MAX * sizeof(gid_t));
+			if (groups == NULL) {
+				ruri_error("{red}Error: malloc failed for groups QwQ\n");
+			}
 			uid_t user_uid = ruri_get_user_uid(user);
 			gid_t user_gid = ruri_get_user_gid(user);
 			if (RURI_PWD_ERRNO != 0) {

--- a/src/elf-magic.c
+++ b/src/elf-magic.c
@@ -43,6 +43,9 @@ struct RURI_ELF_MAGIC *ruri_get_magic(const char *_Nonnull cross_arch)
 	 *
 	 */
 	struct RURI_ELF_MAGIC *ret = (struct RURI_ELF_MAGIC *)malloc(sizeof(struct RURI_ELF_MAGIC));
+	if (ret == NULL) {
+		ruri_error("{red}Error: malloc failed QwQ\n");
+	}
 	// Avoid to simulate the same architecture as host.
 	if (strcmp(cross_arch, RURI_HOST_ARCH) == 0) {
 		ruri_error("Do not simulate the same architecture as host.");

--- a/src/mount.c
+++ b/src/mount.c
@@ -106,6 +106,10 @@ static char *cut_mount_flags(const char *_Nonnull source)
 					ret = strdup(flags[i]);
 				} else {
 					char *tmp = malloc(strlen(ret) + strlen(flags[i]) + 1);
+					if (tmp == NULL) {
+						free(ret);
+						return NULL;
+					}
 					strcpy(tmp, ret);
 					strcat(tmp, flags[i]);
 					free(ret);
@@ -178,6 +182,12 @@ void ruri_convert_mountpoints_to_absolute(struct RURI_CONTAINER *container)
 			ruri_error("{red}Error: realpath() failed for source %s\n", source);
 		}
 		char *new_source = malloc(strlen(flags ? flags : "") + strlen(fstype ? fstype : "") + strlen(abs_source) + 1);
+		if (new_source == NULL) {
+			free(abs_source);
+			free(fstype);
+			free(flags);
+			ruri_error("{red}Failed to allocate memory\n");
+		}
 		strcpy(new_source, flags ? flags : "");
 		strcat(new_source, fstype ? fstype : "");
 		strcat(new_source, abs_source);
@@ -214,6 +224,12 @@ void ruri_convert_mountpoints_to_absolute(struct RURI_CONTAINER *container)
 			ruri_error("{red}Error: realpath() failed for source %s\n", source);
 		}
 		char *new_source = malloc(strlen(flags ? flags : "") + strlen(fstype ? fstype : "") + strlen(abs_source) + 1);
+		if (new_source == NULL) {
+			free(abs_source);
+			free(fstype);
+			free(flags);
+			ruri_error("{red}Failed to allocate memory\n");
+		}
 		strcpy(new_source, flags ? flags : "");
 		strcat(new_source, fstype ? fstype : "");
 		strcat(new_source, abs_source);
@@ -257,6 +273,12 @@ void ruri_convert_rootfs_source_to_absolute(struct RURI_CONTAINER *container)
 			ruri_error("{red}Error: realpath() failed for source %s\n", source);
 		}
 		char *new_source = malloc(strlen(flags ? flags : "") + strlen(fstype ? fstype : "") + strlen(abs_source) + 1);
+		if (new_source == NULL) {
+			free(abs_source);
+			free(fstype);
+			free(flags);
+			ruri_error("{red}Failed to allocate memory\n");
+		}
 		strcpy(new_source, flags ? flags : "");
 		strcat(new_source, fstype ? fstype : "");
 		strcat(new_source, abs_source);
@@ -351,6 +373,9 @@ static char *losetup(const char *_Nonnull img)
 	int devnr = ioctl(loopctlfd, LOOP_CTL_GET_FREE);
 	close(loopctlfd);
 	char *loopfile = malloc(PATH_MAX);
+	if (loopfile == NULL) {
+		return NULL;
+	}
 	memset(loopfile, 0, PATH_MAX);
 	sprintf(loopfile, "/dev/loop%d", devnr);
 	int loopfd = open(loopfile, O_RDWR | O_CLOEXEC);

--- a/src/ps.c
+++ b/src/ps.c
@@ -158,7 +158,10 @@ static void container_ps__(char *_Nonnull container_dir, int container_id)
 	}
 	seekdir(proc_dir, 0);
 	int *pids = malloc((len + 11) * sizeof(int));
-	// For passing clang-tidy.
+	if (pids == NULL) {
+		closedir(proc_dir);
+		ruri_error("{red}Failed to allocate memory for pid list QwQ\n");
+	}
 	memset(pids, 0, (len + 11) * sizeof(int));
 	int i = 0;
 	while ((file = readdir(proc_dir)) != NULL) {
@@ -258,7 +261,10 @@ void ruri_kill_container(struct RURI_CONTAINER *_Nonnull container)
 	}
 	seekdir(proc_dir, 0);
 	int *pids = malloc((len + 11) * sizeof(int));
-	// For passing clang-tidy.
+	if (pids == NULL) {
+		closedir(proc_dir);
+		ruri_error("{red}Failed to allocate memory for pid list QwQ\n");
+	}
 	memset(pids, 0, (len + 11) * sizeof(int));
 	int i = 0;
 	while ((file = readdir(proc_dir)) != NULL) {

--- a/src/rootless.c
+++ b/src/rootless.c
@@ -176,6 +176,9 @@ static void init_rootless_container(struct RURI_CONTAINER *_Nonnull container)
 		devshm_options = strdup("mode=1777");
 	} else {
 		devshm_options = malloc(strlen(container->memory) + strlen("mode=1777") + 114);
+		if (devshm_options == NULL) {
+			ruri_error("{red}Error: malloc failed QwQ\n");
+		}
 		sprintf(devshm_options, "size=%s,mode=1777", container->memory);
 	}
 	mkdir("./dev/shm", S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH | S_IRGRP | S_IWGRP);

--- a/src/ruri.c
+++ b/src/ruri.c
@@ -302,6 +302,9 @@ void ruri_clear_env(char *const *_Nonnull argv)
 	char *path_env = NULL;
 	if (path_env_cont) {
 		path_env = malloc(strlen(path_env_cont) + 16);
+		if (path_env == NULL) {
+			ruri_error("{red}Failed to allocate memory QwQ\n");
+		}
 		snprintf(path_env, strlen(path_env_cont) + 16, "PATH=%s", path_env_cont);
 	}
 	char *no_logs_env = getenv("ruri_no_logs");
@@ -937,8 +940,11 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 							}
 							container->char_devs[i + 1] = malloc(16);
 							container->char_devs[i + 2] = malloc(16);
-							sprintf(container->char_devs[i + 1], "%d", major(st.st_rdev));
-							sprintf(container->char_devs[i + 2], "%d", minor(st.st_rdev));
+							if (container->char_devs[i + 1] == NULL || container->char_devs[i + 2] == NULL) {
+								ruri_error("{red}Failed to allocate memory QwQ\n");
+							}
+							snprintf(container->char_devs[i + 1], 16, "%d", major(st.st_rdev));
+							snprintf(container->char_devs[i + 2], 16, "%d", minor(st.st_rdev));
 							ruri_log("{base}Auto-detected char device: %s (major: %s, minor: %s)\n", container->char_devs[i], container->char_devs[i + 1], container->char_devs[i + 2]);
 						}
 						break;
@@ -1759,6 +1765,9 @@ int ruri(int argc, char **argv)
 	}
 	// Info of container to run.
 	struct RURI_CONTAINER *container = (struct RURI_CONTAINER *)malloc(sizeof(struct RURI_CONTAINER));
+	if (container == NULL) {
+		ruri_error("{red}Failed to allocate memory for container QwQ\n");
+	}
 	// Parse arguments.
 	parse_args(argc, argv, container);
 	// An easter egg for meow flag.

--- a/src/rurienv.c
+++ b/src/rurienv.c
@@ -49,6 +49,9 @@ static bool is_ruri_pid(pid_t pid)
 	// Allocate PATH_MAX + 1 to guarantee room for the null terminator
 	// even when readlink fills the entire buffer.
 	char *pid_ns_mnt_realpath = malloc(PATH_MAX + 1);
+	if (pid_ns_mnt_realpath == NULL) {
+		return false;
+	}
 	ssize_t len = readlink(pid_ns_mnt, pid_ns_mnt_realpath, PATH_MAX);
 	if (len <= 0) {
 		free(pid_ns_mnt_realpath);
@@ -56,6 +59,10 @@ static bool is_ruri_pid(pid_t pid)
 	}
 	pid_ns_mnt_realpath[len] = '\0';
 	char *self_ns_mnt_realpath = malloc(PATH_MAX + 1);
+	if (self_ns_mnt_realpath == NULL) {
+		free(pid_ns_mnt_realpath);
+		return false;
+	}
 	len = readlink("/proc/self/ns/mnt", self_ns_mnt_realpath, PATH_MAX);
 	if (len <= 0) {
 		free(self_ns_mnt_realpath);
@@ -129,6 +136,9 @@ static char *build_container_info(const struct RURI_CONTAINER *_Nonnull containe
 		cap_tmp = cap_to_name(container->drop_caplist[i]);
 		if (cap_tmp == NULL) {
 			drop_caplist[i] = malloc(114);
+			if (drop_caplist[i] == NULL) {
+				ruri_error("{red}Error: malloc failed QwQ\n");
+			}
 			sprintf(drop_caplist[i], "%d", container->drop_caplist[i]);
 		} else {
 			drop_caplist[i] = strdup(cap_tmp);
@@ -312,6 +322,9 @@ struct RURI_CONTAINER *ruri_read_info(struct RURI_CONTAINER *_Nullable container
 		// Return a malloced struct for ruri_umount_container() and ruri_container_ps().
 		if (container == NULL) {
 			container = (struct RURI_CONTAINER *)malloc(sizeof(struct RURI_CONTAINER));
+			if (container == NULL) {
+				ruri_error("{red}Error: malloc failed QwQ\n");
+			}
 			ruri_init_config(container);
 			container->extra_mountpoint[0] = NULL;
 			container->extra_ro_mountpoint[0] = NULL;
@@ -325,6 +338,9 @@ struct RURI_CONTAINER *ruri_read_info(struct RURI_CONTAINER *_Nullable container
 	if (container == NULL) {
 		// For ruri_umount_container().
 		container = (struct RURI_CONTAINER *)malloc(sizeof(struct RURI_CONTAINER));
+		if (container == NULL) {
+			ruri_error("{red}Error: malloc failed QwQ\n");
+		}
 		ruri_init_config(container);
 		int mlen = k2v3_get(char_array, "extra_mountpoint", cache, container->extra_mountpoint, RURI_MAX_MOUNTPOINTS);
 		container->extra_mountpoint[mlen] = NULL;
@@ -386,6 +402,9 @@ struct RURI_CONTAINER *ruri_read_info(struct RURI_CONTAINER *_Nullable container
 	}
 	// Backup container config.
 	struct RURI_CONTAINER *backup = (struct RURI_CONTAINER *)malloc(sizeof(struct RURI_CONTAINER));
+	if (backup == NULL) {
+		ruri_error("{red}Error: malloc failed QwQ\n");
+	}
 	memcpy(backup, container, sizeof(struct RURI_CONTAINER));
 #ifndef DISABLE_LIBCAP
 	// Get capabilities to drop.

--- a/src/signal.c
+++ b/src/signal.c
@@ -73,62 +73,101 @@ enum RURI_PROC_TYPE ruri_proc_mark(enum RURI_PROC_TYPE mark)
 	ret = mark;
 	return ret;
 }
-// Show some extra info when segfault.
+static void sig_write_str(const char *s)
+{
+	if (s == NULL)
+		return;
+	size_t len = 0;
+	while (s[len] != '\0')
+		len++;
+	write(STDERR_FILENO, s, len);
+}
+static void sig_write_int(int val)
+{
+	char tmp[16];
+	int i = 0;
+	unsigned int uval;
+	if (val < 0) {
+		write(STDERR_FILENO, "-", 1);
+		uval = (unsigned int)(-(val + 1)) + 1u;
+	} else {
+		uval = (unsigned int)val;
+	}
+	if (uval == 0) {
+		write(STDERR_FILENO, "0", 1);
+		return;
+	}
+	while (uval > 0) {
+		tmp[i++] = '0' + (char)(uval % 10);
+		uval /= 10;
+	}
+	while (--i >= 0)
+		write(STDERR_FILENO, &tmp[i], 1);
+}
+static void sig_write_uint(unsigned int val)
+{
+	sig_write_int((int)val);
+}
+// Show some extra info when segfault (async-signal-safe).
 static void panic(int sig)
 {
-	/*
-	 * This is very useful when bug reporting,
-	 * because we will get the cmdline that caused the error.
-	 *
-	 */
-	signal(sig, SIG_DFL);
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = SIG_DFL;
+	sigaction(sig, &sa, NULL);
+
 	int clifd = open("/proc/self/cmdline", O_RDONLY | O_CLOEXEC);
 	char buf[1024];
-	ssize_t bufsize = read(clifd, buf, sizeof(buf));
-	close(clifd);
-	cfprintf(stderr, "{base}");
-	cfprintf(stderr, "{base}%s\n", "  .^.   .^.");
-	cfprintf(stderr, "{base}%s\n", "  /⋀\\_ﾉ_/⋀\\");
-	cfprintf(stderr, "{base}%s\n", " /ﾉｿﾉ\\ﾉｿ丶メ");
-	cfprintf(stderr, "{base}%s\n", " ﾙﾘﾘ >  x )ﾘ");
-	cfprintf(stderr, "{base}%s\n", "ﾉノ㇏  ^  ﾉﾉ");
-	cfprintf(stderr, "{base}%s\n", "      ⠁⠁");
-	cfprintf(stderr, "{base}%s\n", "RURI ERROR MESSAGE");
-	cfprintf(stderr, "{base}Seems that it's time to abort.\n");
-	cfprintf(stderr, "{base}SIG: %d\n", sig);
-	cfprintf(stderr, "{base}UID: %u\n", getuid());
-	cfprintf(stderr, "{base}PID: %d\n", getpid());
-	cfprintf(stderr, "{base}PROCESS: %s\n", ruri_get_proc_type());
-	cfprintf(stderr, "{base}CLI: ");
-	for (ssize_t i = 0; i < bufsize - 1; i++) {
+	ssize_t bufsize = 0;
+	if (clifd >= 0) {
+		bufsize = read(clifd, buf, sizeof(buf));
+		close(clifd);
+	}
+	sig_write_str("  .^.   .^.\n");
+	sig_write_str("  /⋀\\_ﾉ_/⋀\\\n");
+	sig_write_str(" /ﾉｿﾉ\\ﾉｿ丶メ\n");
+	sig_write_str(" ﾙﾘﾘ >  x )ﾘ\n");
+	sig_write_str("ﾉノ㇏  ^  ﾉﾉ\n");
+	sig_write_str("      ⠁⠁\n");
+	sig_write_str("RURI ERROR MESSAGE\n");
+	sig_write_str("Seems that it's time to abort.\n");
+	sig_write_str("SIG: ");
+	sig_write_int(sig);
+	sig_write_str("\nUID: ");
+	sig_write_uint(getuid());
+	sig_write_str("\nPID: ");
+	sig_write_int(getpid());
+	sig_write_str("\nPROCESS: ");
+	sig_write_str(ruri_get_proc_type());
+	sig_write_str("\nCLI: ");
+	for (ssize_t i = 0; i < bufsize; i++) {
 		if (buf[i] == '\0') {
-			fputc(' ', stderr);
+			write(STDERR_FILENO, " ", 1);
 		} else {
-			fputc(buf[i], stderr);
+			write(STDERR_FILENO, &buf[i], 1);
 		}
 	}
-	// I'm afraid to have bugs written by myself,
-	// but I'm more afraid that no one will report them.
-	cfprintf(stderr, "{base}\nThis message might caused by an internal error.\n");
-	cfprintf(stderr, "{base}If you think something is wrong, please report at:\n");
-	cfprintf(stderr, "\033[4m{base}%s{clear}\n\n", "https://github.com/rurioss/ruri/issues");
-	exit(114);
+	sig_write_str("\nThis message might caused by an internal error.\n");
+	sig_write_str("If you think something is wrong, please report at:\n");
+	sig_write_str("https://github.com/rurioss/ruri/issues\n\n");
+	_exit(114);
 }
 // Catch coredump signal.
 void ruri_register_signal(void)
 {
-	/*
-	 * Only SIGSEGV means segmentation fault,
-	 * but we catch all signals that might cause coredump.
-	 */
-	signal(SIGABRT, panic);
-	signal(SIGBUS, panic);
-	signal(SIGFPE, panic);
-	signal(SIGILL, panic);
-	signal(SIGQUIT, panic);
-	signal(SIGSEGV, panic);
-	signal(SIGSYS, panic);
-	signal(SIGTRAP, panic);
-	signal(SIGXCPU, panic);
-	signal(SIGXFSZ, panic);
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = panic;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_RESETHAND;
+	sigaction(SIGABRT, &sa, NULL);
+	sigaction(SIGBUS, &sa, NULL);
+	sigaction(SIGFPE, &sa, NULL);
+	sigaction(SIGILL, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
+	sigaction(SIGSEGV, &sa, NULL);
+	sigaction(SIGSYS, &sa, NULL);
+	sigaction(SIGTRAP, &sa, NULL);
+	sigaction(SIGXCPU, &sa, NULL);
+	sigaction(SIGXFSZ, &sa, NULL);
 }


### PR DESCRIPTION
- Replace sprintf with snprintf for user-input buffers (cgroup I/O, cpuset)
- Rewrite signal handler to use only async-signal-safe functions
- Replace signal() with sigaction() using SA_RESETHAND
- Add malloc NULL checks across critical container runtime paths