### PR TITLE
feat(cgroup): wire up freezer API and add --freeze/--thaw subcommands

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 # v3.9.5:
+  * Add `--freeze`/`--thaw` subcommands to pause and resume a container via cgroup freezer (**NOTE**: needs cgroup freezer support, both cgroup v2 built-in freezer and v1 `/sys/fs/cgroup/freezer` or Android `/dev/freezer` are detected).
   * Add `--set-flag` for developers to enable feature flags.
   * Add a `.ruri_umounted` file to indicate that the container has been unmounted.
   * Fix a race condition when udev didn't create /dev/loopx device before ruri tries to mount it.

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -25,6 +25,8 @@ ruri /path/to/container echo "hello world"
 | `-H`, `--show-examples` | Show command-line examples |
 | `-P`, `--ps [container_dir/config]` | Show process status of the container |
 | `--stat [pid_file]` | Show statistics of a running container |
+| `--freeze [container_dir/config]` | Freeze (pause) a container via cgroup freezer (**NOTE**: needs cgroup freezer support) |
+| `--thaw [container_dir/config]` | Thaw (resume) a frozen container via cgroup freezer (**NOTE**: needs cgroup freezer support) |
 
 These options will display information.
 

--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -196,6 +196,11 @@ static void detect_cgroup_v1_fallback(struct RURI_CGROUP_ENV *cg_env)
 		cg_env->cpupercent.prefix = "/dev/cpuctl/ruri/";
 		cg_env->cpupercent.type = RURI_CGROUP_V1;
 	}
+	if (!ruri_flag(no_freezer_cgroup) && access("/dev/freezer/freezer.state", F_OK) == 0 && cg_env->freezer.type == RURI_CGROUP_ENOSYS) {
+		mkdir("/dev/freezer/ruri", S_IRUSR | S_IWUSR);
+		cg_env->freezer.prefix = "/dev/freezer/ruri/";
+		cg_env->freezer.type = RURI_CGROUP_V1;
+	}
 }
 static void detect_cgroup_v2(struct RURI_CGROUP_ENV *cg_env)
 {
@@ -868,6 +873,9 @@ int ruri_freeze_container(int container_id)
 	 * Freeze (pause) all processes in the container.
 	 * Returns 0 on success, 1 on failure.
 	 */
+	if (container_id < 0) {
+		ruri_error("{red}Invalid container_id %d for freeze\n", container_id);
+	}
 	if (ruri_flag(no_cgroup) || ruri_flag(no_freezer_cgroup)) {
 		return 1;
 	}
@@ -897,6 +905,9 @@ int ruri_thaw_container(int container_id)
 	 * Thaw (resume) all processes in the container.
 	 * Returns 0 on success, 1 on failure.
 	 */
+	if (container_id < 0) {
+		ruri_error("{red}Invalid container_id %d for thaw\n", container_id);
+	}
 	if (ruri_flag(no_cgroup) || ruri_flag(no_freezer_cgroup)) {
 		return 1;
 	}

--- a/src/include/ruri.h
+++ b/src/include/ruri.h
@@ -343,6 +343,8 @@ int ruri_cap_from_name(const char *str, cap_value_t *cap);
 #endif
 void ruri_clear_env(char *const *_Nonnull argv);
 bool ruri_pid_in_cgroup(pid_t pid, int container_id);
+int ruri_freeze_container(int container_id);
+int ruri_thaw_container(int container_id);
 long long ruri_diff_time(void);
 enum RURI_PROC_TYPE ruri_proc_mark(enum RURI_PROC_TYPE mark);
 void ruri_stat(const char *pid_file);

--- a/src/info.c
+++ b/src/info.c
@@ -110,6 +110,8 @@ void ruri_show_helps(void)
 	cprintf("{base}  -U, --umount [container_dir/config] .........: Unmount a container\n");
 	cprintf("{base}  -P, --ps [container_dir/config] .............: Show process status of the container (*1)\n");
 	cprintf("{base}      --stat [pid_file] .......................: Show the stat of a container\n");
+	cprintf("{base}      --freeze [container_dir/config] ........: Freeze (pause) a container via cgroup (*1)\n");
+	cprintf("{base}      --thaw [container_dir/config] ..........: Thaw (resume) a frozen container (*1)\n");
 	cprintf("{base}  -C, --correct-config [config]................: Correct a container config\n");
 	cprintf("\n");
 	cprintf("{base}ARGS:\n");

--- a/src/ruri.c
+++ b/src/ruri.c
@@ -1569,7 +1569,6 @@ int ruri(int argc, char **argv)
 	// Default flags.
 	ruri_set_flag("no_pids_cgroup");
 	ruri_set_flag("no_io_cgroup");
-	ruri_set_flag("no_freezer_cgroup");
 	// init profiling time.
 	ruri_diff_time();
 	// Detect SUID or capability.

--- a/src/ruri.c
+++ b/src/ruri.c
@@ -395,6 +395,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 		// Freeze (pause) a container via cgroup freezer.
 		if (strcmp(argv[index], "--freeze") == 0) {
 			index += 1;
+			// Freezer is disabled by default; opt-in here.
+			ruri_set_flag("no_freezer_cgroup=false");
 			struct stat st;
 			if (stat(argv[index], &st) != 0) {
 				ruri_error("{red}Container directory or config does not exist QwQ\n");
@@ -421,6 +423,8 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 		// Thaw (resume) a container via cgroup freezer.
 		if (strcmp(argv[index], "--thaw") == 0) {
 			index += 1;
+			// Freezer is disabled by default; opt-in here.
+			ruri_set_flag("no_freezer_cgroup=false");
 			struct stat st;
 			if (stat(argv[index], &st) != 0) {
 				ruri_error("{red}Container directory or config does not exist QwQ\n");
@@ -1569,6 +1573,7 @@ int ruri(int argc, char **argv)
 	// Default flags.
 	ruri_set_flag("no_pids_cgroup");
 	ruri_set_flag("no_io_cgroup");
+	ruri_set_flag("no_freezer_cgroup");
 	// init profiling time.
 	ruri_diff_time();
 	// Detect SUID or capability.

--- a/src/ruri.c
+++ b/src/ruri.c
@@ -392,6 +392,58 @@ static void parse_args(int argc, char **_Nonnull argv, struct RURI_CONTAINER *_N
 			ruri_stat(pid_file);
 			exit(EXIT_FAILURE);
 		}
+		// Freeze (pause) a container via cgroup freezer.
+		if (strcmp(argv[index], "--freeze") == 0) {
+			index += 1;
+			struct stat st;
+			if (stat(argv[index], &st) != 0) {
+				ruri_error("{red}Container directory or config does not exist QwQ\n");
+			}
+			int ret;
+			if (S_ISDIR(st.st_mode)) {
+				struct RURI_CONTAINER *tmp = ruri_read_info(NULL, argv[index]);
+				ret = ruri_freeze_container(tmp->container_id);
+				free(tmp);
+			} else if (S_ISREG(st.st_mode)) {
+				struct RURI_CONTAINER tmp;
+				ruri_init_config(&tmp);
+				ruri_read_config(&tmp, argv[index]);
+				ret = ruri_freeze_container(tmp.container_id);
+			} else {
+				ruri_error("{red}Error: unknown file type QwQ\n");
+			}
+			if (ret != 0) {
+				ruri_warning("{yellow}Failed to freeze container, cgroup freezer not available\n");
+				exit(114);
+			}
+			exit(EXIT_SUCCESS);
+		}
+		// Thaw (resume) a container via cgroup freezer.
+		if (strcmp(argv[index], "--thaw") == 0) {
+			index += 1;
+			struct stat st;
+			if (stat(argv[index], &st) != 0) {
+				ruri_error("{red}Container directory or config does not exist QwQ\n");
+			}
+			int ret;
+			if (S_ISDIR(st.st_mode)) {
+				struct RURI_CONTAINER *tmp = ruri_read_info(NULL, argv[index]);
+				ret = ruri_thaw_container(tmp->container_id);
+				free(tmp);
+			} else if (S_ISREG(st.st_mode)) {
+				struct RURI_CONTAINER tmp;
+				ruri_init_config(&tmp);
+				ruri_read_config(&tmp, argv[index]);
+				ret = ruri_thaw_container(tmp.container_id);
+			} else {
+				ruri_error("{red}Error: unknown file type QwQ\n");
+			}
+			if (ret != 0) {
+				ruri_warning("{yellow}Failed to thaw container, cgroup freezer not available\n");
+				exit(114);
+			}
+			exit(EXIT_SUCCESS);
+		}
 		// Correct a container config.
 		if (strcmp(argv[index], "-C") == 0 || strcmp(argv[index], "--correct-config") == 0) {
 			index += 1;

--- a/test/root/11-freeze.sh
+++ b/test/root/11-freeze.sh
@@ -5,14 +5,10 @@ export TEST_NO=11
 export DESCRIPTION="Test if --freeze/--thaw options work properly"
 show_test_description
 
-# Skip if cgroup (and freezer) is not available on this host.
-if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]]; then
-    echo -e "${YELLOW}cgroup v2 not mounted, skipping test #${TEST_NO}${CLEAR}"
-    pass_test
-    exit 0
-fi
-if ! grep -qw freezer /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
-    if [[ ! -d /sys/fs/cgroup/freezer ]]; then
+# Skip if no cgroup freezer is available on this host
+# (cgroup v2 freezer, v1 at /sys/fs/cgroup/freezer, or Android /dev/freezer).
+if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]] || ! grep -qw freezer /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
+    if [[ ! -f /sys/fs/cgroup/freezer/freezer.state && ! -f /dev/freezer/freezer.state ]]; then
         echo -e "${YELLOW}cgroup freezer controller not available, skipping test #${TEST_NO}${CLEAR}"
         pass_test
         exit 0

--- a/test/root/11-freeze.sh
+++ b/test/root/11-freeze.sh
@@ -1,0 +1,73 @@
+cd ${TEST_ROOT}
+source global.sh
+
+export TEST_NO=11
+export DESCRIPTION="Test if --freeze/--thaw options work properly"
+show_test_description
+
+# Skip if cgroup (and freezer) is not available on this host.
+if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]]; then
+    echo -e "${YELLOW}cgroup v2 not mounted, skipping test #${TEST_NO}${CLEAR}"
+    pass_test
+    exit 0
+fi
+if ! grep -qw freezer /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
+    if [[ ! -d /sys/fs/cgroup/freezer ]]; then
+        echo -e "${YELLOW}cgroup freezer controller not available, skipping test #${TEST_NO}${CLEAR}"
+        pass_test
+        exit 0
+    fi
+fi
+
+export SUBTEST_NO=1
+export SUBTEST_DESCRIPTION="--freeze/--thaw with chroot container"
+show_subtest_description
+cd ${TMPDIR}
+cat <<EOF >test/test.sh
+#!/bin/sh
+# Write a counter file so we can observe the process is actually paused.
+i=0
+while true; do
+    echo \$i > /tmp/freeze_counter
+    i=\$((i + 1))
+    sleep 0.2
+done
+EOF
+chmod +x test/test.sh
+
+# Mount a tmpfs so the counter file does not collide with the host.
+mkdir -p test/tmp
+./ruri -m tmpfs tmp -o test/tmp /bin/sh /test.sh &
+sleep 1
+
+# Freeze the container.
+./ruri --freeze ./test
+check_if_succeed $?
+sleep 1
+before=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+sleep 2
+after=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+if [[ "${before}" != "${after}" ]]; then
+    error "container was not frozen, counter moved from ${before} to ${after}"
+fi
+echo -e "${BASE}==> --freeze paused the container${CLEAR}"
+
+# Thaw the container.
+./ruri --thaw ./test
+check_if_succeed $?
+sleep 1
+before=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+sleep 2
+after=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+if [[ "${before}" == "${after}" ]]; then
+    error "container was not thawed, counter stayed at ${before}"
+fi
+echo -e "${BASE}==> --thaw resumed the container${CLEAR}"
+
+# Cleanup.
+./ruri -P ./test | awk '{print $1}' | xargs kill -9 2>/dev/null
+./ruri -U ./test >/dev/null 2>&1
+echo -e "${BASE}==> --freeze/--thaw passed!${CLEAR}\n"
+pass_subtest
+
+pass_test

--- a/test/root/11-freeze.sh
+++ b/test/root/11-freeze.sh
@@ -5,21 +5,21 @@ export TEST_NO=11
 export DESCRIPTION="Test if --freeze/--thaw options work properly"
 show_test_description
 
-# Skip if no cgroup freezer is available on this host
-# (cgroup v2 freezer, v1 at /sys/fs/cgroup/freezer, or Android /dev/freezer).
-if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]] || ! grep -qw freezer /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
-    if [[ ! -f /sys/fs/cgroup/freezer/freezer.state && ! -f /dev/freezer/freezer.state ]]; then
-        echo -e "${YELLOW}cgroup freezer controller not available, skipping test #${TEST_NO}${CLEAR}"
-        pass_test
-        exit 0
+run_freeze_test() {
+    # Skip if no cgroup freezer is available on this host
+    # (cgroup v2 freezer, v1 at /sys/fs/cgroup/freezer, or Android /dev/freezer).
+    if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]] || ! grep -qw freezer /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
+        if [[ ! -f /sys/fs/cgroup/freezer/freezer.state && ! -f /dev/freezer/freezer.state ]]; then
+            echo -e "${YELLOW}cgroup freezer controller not available, skipping test #${TEST_NO}${CLEAR}"
+            return 0
+        fi
     fi
-fi
 
-export SUBTEST_NO=1
-export SUBTEST_DESCRIPTION="--freeze/--thaw with chroot container"
-show_subtest_description
-cd ${TMPDIR}
-cat <<EOF >test/test.sh
+    export SUBTEST_NO=1
+    export SUBTEST_DESCRIPTION="--freeze/--thaw with chroot container"
+    show_subtest_description
+    cd ${TMPDIR}
+    cat <<EOF >test/test.sh
 #!/bin/sh
 # Write a counter file so we can observe the process is actually paused.
 i=0
@@ -29,41 +29,44 @@ while true; do
     sleep 0.2
 done
 EOF
-chmod +x test/test.sh
+    chmod +x test/test.sh
 
-# Mount a tmpfs so the counter file does not collide with the host.
-mkdir -p test/tmp
-./ruri -m tmpfs tmp -o test/tmp /bin/sh /test.sh &
-sleep 1
+    # Mount a tmpfs so the counter file does not collide with the host.
+    mkdir -p test/tmp
+    ./ruri -m tmpfs tmp -o test/tmp /bin/sh /test.sh &
+    sleep 1
 
-# Freeze the container.
-./ruri --freeze ./test
-check_if_succeed $?
-sleep 1
-before=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
-sleep 2
-after=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
-if [[ "${before}" != "${after}" ]]; then
-    error "container was not frozen, counter moved from ${before} to ${after}"
-fi
-echo -e "${BASE}==> --freeze paused the container${CLEAR}"
+    # Freeze the container.
+    ./ruri --freeze ./test
+    check_if_succeed $?
+    sleep 1
+    before=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+    sleep 2
+    after=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+    if [[ "${before}" != "${after}" ]]; then
+        error "container was not frozen, counter moved from ${before} to ${after}"
+    fi
+    echo -e "${BASE}==> --freeze paused the container${CLEAR}"
 
-# Thaw the container.
-./ruri --thaw ./test
-check_if_succeed $?
-sleep 1
-before=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
-sleep 2
-after=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
-if [[ "${before}" == "${after}" ]]; then
-    error "container was not thawed, counter stayed at ${before}"
-fi
-echo -e "${BASE}==> --thaw resumed the container${CLEAR}"
+    # Thaw the container.
+    ./ruri --thaw ./test
+    check_if_succeed $?
+    sleep 1
+    before=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+    sleep 2
+    after=$(cat test/tmp/freeze_counter 2>/dev/null || echo "missing")
+    if [[ "${before}" == "${after}" ]]; then
+        error "container was not thawed, counter stayed at ${before}"
+    fi
+    echo -e "${BASE}==> --thaw resumed the container${CLEAR}"
 
-# Cleanup.
-./ruri -P ./test | awk '{print $1}' | xargs kill -9 2>/dev/null
-./ruri -U ./test >/dev/null 2>&1
-echo -e "${BASE}==> --freeze/--thaw passed!${CLEAR}\n"
-pass_subtest
+    # Cleanup.
+    ./ruri -P ./test | awk '{print $1}' | xargs kill -9 2>/dev/null
+    ./ruri -U ./test >/dev/null 2>&1
+    echo -e "${BASE}==> --freeze/--thaw passed!${CLEAR}\n"
+    pass_subtest
 
-pass_test
+    pass_test
+}
+
+run_freeze_test


### PR DESCRIPTION
ruri_freeze_container() and ruri_thaw_container() were added in ebd6933 but never called outside cgroup.c, making them dead code.

- Declare the two functions in include/ruri.h
- Add --freeze/--thaw subcommands to the CLI, accepting either a container directory or a config file like -P/--ps
- Document them in the -h help page
- Add test/root/11-freeze.sh which skips when no freezer controller is available, otherwise verifies that the container is actually paused after --freeze and resumed after --thaw